### PR TITLE
fix: add `FLAG_ACTIVITY_NEW_TASK` to share HAR intent.

### DIFF
--- a/inspektor/src/androidMain/kotlin/com/gyanoba/inspektor/platform/FileSharer.android.kt
+++ b/inspektor/src/androidMain/kotlin/com/gyanoba/inspektor/platform/FileSharer.android.kt
@@ -22,6 +22,10 @@ internal class FileSharerImpl(private val context: Context) : FileSharer {
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
 
-        context.startActivity(Intent.createChooser(intent, "Share file"))
+        context.startActivity(
+            Intent.createChooser(intent, "Share file").apply {
+                setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
     }
 }


### PR DESCRIPTION
The share intent was missing the `FLAG_ACTIVITY_NEW_TASK` flag, which is required to launch an activity from a non-activity context (e.g., from a service or broadcast receiver).

This commit adds the missing flag to ensure that the share intent can be launched correctly in all contexts.